### PR TITLE
Miner.rb resolving relative references 

### DIFF
--- a/miner/miner.rb
+++ b/miner/miner.rb
@@ -1,5 +1,5 @@
 require_relative './listener.rb'
-require_relative '../blockchain.rb'
+require_relative '../lib/blockchain.rb'
 
 
 


### PR DESCRIPTION
I got errors on running miner:
```
$ ruby ./miner/miner.rb 
Traceback (most recent call last):
	1: from ./miner/miner.rb:2:in `<main>'
./miner/miner.rb:2:in `require_relative': cannot load such file -- .../odyn/blockchain.rb (LoadError)
```
Seems to be that blockchain.rb moved into the lib directory.